### PR TITLE
Added Russian translation

### DIFF
--- a/index.ru.json
+++ b/index.ru.json
@@ -1,0 +1,47 @@
+{
+    "_author": "nurupo and carbon-14",
+    "_language": "Русский",
+    "_comment": "Only translate from this file, not the others!",
+    "_ind": 0,
+
+    "lf_title": "Tox: Новый способ обмена сообщениями",
+
+    "nv_home": "Начало",
+    "nv_about": "О проекте",
+    "nv_features": "О программе",
+    "nv_contribute": "Стать участником",
+    "nv_wiki": "Вики",
+    "slogan": "Tox: Новый способ обмена сообщениями",
+    "downloads": "Загрузки",
+
+    "os_choose": "Выберите вашу операционную систему.",
+    "os_fail": "Мы не смогли определить вашу операционную систему.",
+    "os_detected_wrong": "Загрузить Tox для ",
+    "os_windows": "Windows",
+    "os_mac": "Macintosh",
+    "os_linux": "Linux",
+    "os_iphone": "iOS",
+    "os_android": "Android",
+    "os_other": "Другие",
+    "os_os": "Operating System",
+    "os_arch_32": "32 bit",
+    "os_arch_64": "64 bit",
+    "os_arch_gen": "Generic",
+
+
+    "download_warning": "Ночные автоматические сборки не для слабых сердцем, вы можете столкнуться с ошибками, сбоями, и большой дозой недовольства. Будьте осторожны!",
+    "download_started": "Ваша загрузка началась. Спасибо, что вы выбрали Tox!",
+    "download_started2": "Ваша загрузка началась. Приятного общения!",
+    "download_compile": "Скрипты для автоматической сборки",
+
+    "sect6_mailinglist_title": "Будьте в курсе событий",
+    "sect6_mailinglist": "Подпишитесь на рассылку чтобы узнавать о ходе разработки Tox.",
+    "sect6_email": "адрес электронной почты",
+
+    "sect6_needhelp": "Нужна помощь?",
+    "sect6_githubtoirc": "Начните свой проект и свяжитесь с нами на <span class=\"text normal\">GitHub</span>, или в чате <a href=\"ircs://irc.freenode.net/tox\" class=\"text bold underline color theme\">IRC</a>!",
+
+    "dev_links": "Ссылки для разработчиков",
+    "dev_blog": "Блог разработчиков",
+    "dev_docs": "Документация"
+}


### PR DESCRIPTION
@Proplex @stqism, did you forget to remove the email subscription lines from the english language file or it was intentional? 

As far as translation goes, there are many common lines between [Tox/Tox-Website](https://github.com/Tox/Tox-Website) and here, it would be weird if some new contributor translated menu options (and other common translations) differently from ones in Tox/Tox-Website. It would be better to make a single top-level translation file for each language with all those common lines like `lf_title`, `nv_home`, `nv_about`, `nv_features`, `nv_contribute`, `nv_wiki`, `slogan`, `dev_links`, `dev_blog`, `dev_docsetc`, etc, and just leave page-specific lines in downloads/ file.

English translation file misses lines about Gentoo, etc.

Also, why do we have separate repos for the whole website and just for the downloads page? Will you be making a new repo for every single page you add? : ) Just merge this in Tox-Website. Not to mention that the header part of Downloads page is noticeably different from one on the main page, as if Downloads page was really developed in a separate repo by different web designers/developers:

![1](https://cloud.githubusercontent.com/assets/1855294/3573314/d51b2844-0b70-11e4-8c78-f62d1374443f.png)

![2](https://cloud.githubusercontent.com/assets/1855294/3573316/d776952e-0b70-11e4-8224-b887257c2374.png)
